### PR TITLE
Added support for the metering and reporting capabilities of the HS110

### DIFF
--- a/TPLinkSmartDevices/Data/PowerData.cs
+++ b/TPLinkSmartDevices/Data/PowerData.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace TPLinkSmartDevices.Data
+{
+    /// <summary>
+    /// Encapsulates JSON data structure for current energy use as metered by the HS110 Smart Energy Meter.
+    /// </summary>
+    public class PowerData
+    {
+        private readonly dynamic _powerData;
+
+        public PowerData(dynamic powerData)
+        {
+            _powerData = powerData;
+        }
+
+        /// <summary>
+        /// Current measured voltage in volts.
+        /// </summary>
+        public double Voltage => _powerData.voltage_mv / 1000.0d;
+
+        /// <summary>
+        /// Current measured amperage in amps.
+        /// </summary>
+        public double Amperage => _powerData.current_ma / 1000.0d;
+
+        /// <summary>
+        /// Current measured power usage in watts.
+        /// </summary>
+        public double Power => _powerData.power_mw / 1000.0d;
+
+        /// <summary>
+        /// Current total power consumption in kilowatthours.
+        /// </summary>
+        public double Total => _powerData.total_wh / 1000.0d;
+
+        public int ErrorCode => _powerData.err_code;
+
+        public override string ToString()
+        {
+            return $"{Voltage/1000.0d:0.0} Volt, {Amperage/1000.0d:0.00} Ampere, {Power/1000.0:0.00} Watt";
+        }
+    }
+}

--- a/TPLinkSmartDevices/Devices/TPLinkSmartMeterPlug.cs
+++ b/TPLinkSmartDevices/Devices/TPLinkSmartMeterPlug.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using TPLinkSmartDevices.Data;
+
+namespace TPLinkSmartDevices.Devices
+{
+    public class TPLinkSmartMeterPlug : TPLinkSmartPlug
+    {
+        public TPLinkSmartMeterPlug(string hostname) : base(hostname)
+        {
+        }
+
+        public PowerData CurrentPowerUsage => new PowerData(Execute("emeter", "get_realtime"));
+
+    }
+}

--- a/TPLinkSmartDevices/Devices/TPLinkSmartPlug.cs
+++ b/TPLinkSmartDevices/Devices/TPLinkSmartPlug.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace TPLinkSmartDevices.Devices
 {
@@ -52,8 +52,8 @@ namespace TPLinkSmartDevices.Devices
             if ((int)sysInfo.on_time == 0)
                 PoweredOnSince = default(DateTime);
             else
-                PoweredOnSince = DateTime.Now - TimeSpan.FromSeconds((int)sysInfo.system.get_sysinfo.on_time);
-            
+                PoweredOnSince = DateTime.Now - TimeSpan.FromSeconds((int)sysInfo.on_time);
+
             Refresh(sysInfo);
         }
     }

--- a/TPLinkSmartDevices/TPLinkDiscovery.cs
+++ b/TPLinkSmartDevices/TPLinkDiscovery.cs
@@ -64,9 +64,11 @@ namespace TPLinkSmartDevices
                 var sys_info = ((dynamic)JObject.Parse(message)).system.get_sysinfo;
 
                 TPLinkSmartDevice device = null;
-                if (((string)sys_info.model).StartsWith("HS"))
+            string model = (string) sys_info.model;
+
+            if (model.StartsWith("HS"))
                     device = new TPLinkSmartPlug(ip.Address.ToString());
-                else if (((string)sys_info.model).StartsWith("LB"))
+            else if (model.StartsWith("LB"))
                     device = new TPLinkSmartBulb(ip.Address.ToString());
 
                 if (device != null)

--- a/TPLinkSmartDevices/TPLinkDiscovery.cs
+++ b/TPLinkSmartDevices/TPLinkDiscovery.cs
@@ -58,8 +58,6 @@ namespace TPLinkSmartDevices
             if (discoveryComplete) //Prevent ObjectDisposedException/NullReferenceException when the Close() function is called
                 return;
 
-            try
-            {
                 IPEndPoint ip = new IPEndPoint(IPAddress.Any, PORT_NUMBER);
                 byte[] bytes = udp.EndReceive(ar, ref ip);
                 var message = Encoding.ASCII.GetString(Messaging.SmartHomeProtocolEncoder.Decrypt(bytes));
@@ -73,9 +71,7 @@ namespace TPLinkSmartDevices
 
                 if (device != null)
                     DiscoveredDevices.Add(device);
-            }
-            catch (Exception ex) { }
-
+            
             if (udp != null)
                 StartListening();
         }

--- a/TPLinkSmartDevices/TPLinkDiscovery.cs
+++ b/TPLinkSmartDevices/TPLinkDiscovery.cs
@@ -58,21 +58,23 @@ namespace TPLinkSmartDevices
             if (discoveryComplete) //Prevent ObjectDisposedException/NullReferenceException when the Close() function is called
                 return;
 
-                IPEndPoint ip = new IPEndPoint(IPAddress.Any, PORT_NUMBER);
-                byte[] bytes = udp.EndReceive(ar, ref ip);
-                var message = Encoding.ASCII.GetString(Messaging.SmartHomeProtocolEncoder.Decrypt(bytes));
-                var sys_info = ((dynamic)JObject.Parse(message)).system.get_sysinfo;
+            IPEndPoint ip = new IPEndPoint(IPAddress.Any, PORT_NUMBER);
+            byte[] bytes = udp.EndReceive(ar, ref ip);
+            var message = Encoding.ASCII.GetString(Messaging.SmartHomeProtocolEncoder.Decrypt(bytes));
+            var sys_info = ((dynamic)JObject.Parse(message)).system.get_sysinfo;
 
-                TPLinkSmartDevice device = null;
+            TPLinkSmartDevice device = null;
             string model = (string) sys_info.model;
 
-            if (model.StartsWith("HS"))
-                    device = new TPLinkSmartPlug(ip.Address.ToString());
+            if (model.StartsWith("HS110"))
+                device = new TPLinkSmartMeterPlug(ip.Address.ToString());
+            else if (model.StartsWith("HS"))
+                device = new TPLinkSmartPlug(ip.Address.ToString());
             else if (model.StartsWith("LB"))
-                    device = new TPLinkSmartBulb(ip.Address.ToString());
+                device = new TPLinkSmartBulb(ip.Address.ToString());
 
-                if (device != null)
-                    DiscoveredDevices.Add(device);
+            if (device != null)
+                DiscoveredDevices.Add(device);
             
             if (udp != null)
                 StartListening();

--- a/TPLinkSmartDevices/TPLinkSmartDevices.csproj
+++ b/TPLinkSmartDevices/TPLinkSmartDevices.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -30,8 +30,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.10.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.12.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/TPLinkSmartDevices/TPLinkSmartDevices.csproj
+++ b/TPLinkSmartDevices/TPLinkSmartDevices.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -43,6 +43,8 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Data\PowerData.cs" />
+    <Compile Include="Devices\TPLinkSmartMeterPlug.cs" />
     <Compile Include="Messaging\IMessageCache.cs" />
     <Compile Include="Messaging\ManualMessageCache.cs" />
     <Compile Include="Messaging\NoMessageCache.cs" />

--- a/TPLinkSmartDevices/packages.config
+++ b/TPLinkSmartDevices/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="12.0.1" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
**I had to make a change to the parsing code that may break devices other than the HS110 (see https://github.com/anthturner/TPLinkSmartDevices/commit/f3ae9e5a30a55b1d74ee09a46b446f0332419035 for more details).**

Basically I had to change this 

`PoweredOnSince = DateTime.Now - TimeSpan.FromSeconds((int)sysInfo.system.get_sysinfo.on_time);`

to this 

`PoweredOnSince = DateTime.Now - TimeSpan.FromSeconds((int)sysInfo.on_time);`

This might be a change needed for all devices or it might be a change that is only needed for the HS110. I cannot test this because I only own the HS110. I reccommend testing this before accepting this pull request.