### PR TITLE
Implemented the countdown feature + improved discovery efficiency + multi-language support

### DIFF
--- a/TPLinkSmartDevices/Devices/TPLinkSmartPlug.cs
+++ b/TPLinkSmartDevices/Devices/TPLinkSmartPlug.cs
@@ -1,3 +1,4 @@
+using Newtonsoft.Json.Linq;
 using System;
 
 namespace TPLinkSmartDevices.Devices
@@ -55,6 +56,29 @@ namespace TPLinkSmartDevices.Devices
                 PoweredOnSince = DateTime.Now - TimeSpan.FromSeconds((int)sysInfo.on_time);
 
             Refresh(sysInfo);
+        }
+		
+        /// <summary>
+        /// Configure the device so that it goes in the specified state at the delay expiration
+        /// </summary>
+        /// <param name="stateAtDelayExpiration"></param>
+        /// <param name="delay"></param>
+        /// <param name="name"></param>
+        /// <returns>The rule ID (could eventually be useful for changing the existing rule...)</returns>
+        public string SetCountDown(bool stateAtDelayExpiration, TimeSpan delay, string name = "")
+        {
+            // Clean-up the previous rule - if not done, the device responds with a "table is full" error
+            Execute("count_down", "delete_all_rules", null, null);
+
+            var retValue = Execute("count_down", "add_rule", null, new JObject
+                {
+                    new JProperty("enable", 1),
+                    new JProperty("delay", delay.Seconds),
+                    new JProperty("act", stateAtDelayExpiration? 1 : 0),
+                    new JProperty("name", name)
+                });
+
+            return retValue["id"];
         }
     }
 }

--- a/TPLinkSmartDevices/Devices/TPLinkSmartPlug.cs
+++ b/TPLinkSmartDevices/Devices/TPLinkSmartPlug.cs
@@ -73,7 +73,7 @@ namespace TPLinkSmartDevices.Devices
             var retValue = Execute("count_down", "add_rule", null, new JObject
                 {
                     new JProperty("enable", 1),
-                    new JProperty("delay", delay.Seconds),
+                    new JProperty("delay", Convert.ToInt32(delay.TotalSeconds)),
                     new JProperty("act", stateAtDelayExpiration? 1 : 0),
                     new JProperty("name", name)
                 });

--- a/TPLinkSmartDevices/Messaging/SmartHomeProtocolMessage.cs
+++ b/TPLinkSmartDevices/Messaging/SmartHomeProtocolMessage.cs
@@ -38,7 +38,7 @@ namespace TPLinkSmartDevices.Messaging
             {
                 object argObject;
                 if (Value != null)
-                    argObject = new JObject { new JProperty(Argument, Value) };
+                    argObject = Argument != null? new JObject { new JProperty(Argument, Value) }: Value;
                 else
                     argObject = Argument;
 

--- a/TPLinkSmartDevices/Messaging/SmartHomeProtocolMessage.cs
+++ b/TPLinkSmartDevices/Messaging/SmartHomeProtocolMessage.cs
@@ -95,7 +95,7 @@ namespace TPLinkSmartDevices.Messaging
             }
             client.Close();
 
-            var decrypted = Encoding.ASCII.GetString(SmartHomeProtocolEncoder.Decrypt(packet)).Trim('\0');
+            var decrypted = Encoding.UTF8.GetString(SmartHomeProtocolEncoder.Decrypt(packet)).Trim('\0');
 
             var subResult = (dynamic)((JObject)JObject.Parse(decrypted)[System])[Command];
             if (subResult["err_code"] != null && subResult.err_code != 0)

--- a/TPLinkSmartDevices/TPLinkDiscovery.cs
+++ b/TPLinkSmartDevices/TPLinkDiscovery.cs
@@ -23,15 +23,17 @@ namespace TPLinkSmartDevices
         IAsyncResult _asyncResult = null;
 
         private bool discoveryComplete = false;
-
+        private int maxNumberOfDevicesToDiscover = -1;
+        private CancellationTokenSource delayCancellationToken = new CancellationTokenSource();
         public TPLinkDiscovery()
         {
             DiscoveredDevices = new List<TPLinkSmartDevice>();
         }
 
-        public async Task<List<TPLinkSmartDevice>> Discover(int port=9999, int timeout=5000)
+        public async Task<List<TPLinkSmartDevice>> Discover(int port=9999, int timeout=5000, int maxNumberOfDevicesToDiscover=-1)
         {
             discoveryComplete = false;
+            this.maxNumberOfDevicesToDiscover = maxNumberOfDevicesToDiscover;
 
             DiscoveredDevices.Clear();
             PORT_NUMBER = port;
@@ -41,7 +43,7 @@ namespace TPLinkSmartDevices
             udp = new UdpClient(PORT_NUMBER);
             StartListening();
 
-            return await Task.Delay(timeout).ContinueWith(t =>
+            return await Task.Delay(TimeSpan.FromMilliseconds(timeout), delayCancellationToken.Token).ContinueWith(t =>
             {
                 discoveryComplete = true;
                 udp.Close();
@@ -79,6 +81,13 @@ namespace TPLinkSmartDevices
             {
                 DiscoveredDevices.Add(device);
                 OnDeviceFound(device);
+
+                // If the caller has specified a maximum number of devices to discover, stop waiting after we've
+                // reached this count
+                if (maxNumberOfDevicesToDiscover > 0 && DiscoveredDevices.Count >= maxNumberOfDevicesToDiscover)
+                {
+                    delayCancellationToken.Cancel();
+                }
             }
             if (udp != null)
                 StartListening();

--- a/TPLinkSmartDevices/TPLinkDiscovery.cs
+++ b/TPLinkSmartDevices/TPLinkDiscovery.cs
@@ -64,7 +64,7 @@ namespace TPLinkSmartDevices
 
             IPEndPoint ip = new IPEndPoint(IPAddress.Any, PORT_NUMBER);
             byte[] bytes = udp.EndReceive(ar, ref ip);
-            var message = Encoding.ASCII.GetString(Messaging.SmartHomeProtocolEncoder.Decrypt(bytes));
+            var message = Encoding.UTF8.GetString(Messaging.SmartHomeProtocolEncoder.Decrypt(bytes));
             var sys_info = ((dynamic)JObject.Parse(message)).system.get_sysinfo;
 
             TPLinkSmartDevice device = null;

--- a/TPLinkSmartDevices/TPLinkSmartDevices.csproj
+++ b/TPLinkSmartDevices/TPLinkSmartDevices.csproj
@@ -31,7 +31,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.12.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/TPLinkSmartDevices/packages.config
+++ b/TPLinkSmartDevices/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="12.0.1" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
I hope it's not a problem to propose three separate improvements in a single PR but each one of them involves very little code change.

- I implemented the countdown feature, whereby the on/off state of the device can be set when a countdown expires. Since I only own smart switches (HS200 - which incidentally are discovered as smart plugs), I don't know what other devices support this feature. I guess the countdown support could eventually be moved in the device base class.

- I also improved the Discover() function with an optional "maxNumberOfDevicesToDiscover" parameter. The discovery returns immediately when the specified number of devices have been discovered, which makes the discovery much faster when you know how many devices are installed. There is no need to wait for an amount of time.

- Finally, the device responses are decoded as UTF-8 strings for multi-language support (my device's aliases have accented characters).

Hope this helps.