### PR TITLE
add ReadRealtimePowerData()/ReadDailyStatistic() for TPLinkSmartStrip

### DIFF
--- a/TPLinkSmartDevice.NETCore/Data/DailyPowerData.cs
+++ b/TPLinkSmartDevice.NETCore/Data/DailyPowerData.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace TPLinkSmartDevices.Data
+{
+    /// <summary>
+    /// Daily power statistics
+    /// </summary>
+    public class DailyPowerData
+    {
+        /// <summary>
+        /// Date
+        /// </summary>
+        public DateTime Date { get; set; }
+        /// <summary>
+        /// Power (Wh)
+        /// </summary>
+        public int WattHours { get; set; }
+
+        /// <summary>
+        /// constructor
+        /// </summary>
+        /// <param name="rawData">JSON raw object</param>
+        public DailyPowerData(dynamic rawData)
+        {
+            Date = new DateTime((int)rawData.year, (int)rawData.month, (int)rawData.day);
+            WattHours = rawData.energy_wh;
+        }
+
+        public override string ToString()
+        {
+            return $"{Date:yyyy-MM-dd} {WattHours} Wh";
+        }
+    }
+}


### PR DESCRIPTION
Suggest adding two power data collecting APIs:

* ReadRealtimePowerData() - get real-time PowerData for specific plug
* ReadDailyStatistic() - get daily watt-hours data for specific pulg in specific month, if no year/month assigned, it get data for this month.
